### PR TITLE
Fix the language ID for Japanese

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "en-GB",
     "pt-BR",
     "fr",
-    "ja-JP"
+    "ja"
   ],
   "default_locale": "en-US"
 }


### PR DESCRIPTION
Most browsers only send "ja", not "ja-JP", so use that.