### PR TITLE
Corrected the link to clahub for signing contribution agreements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To create a new language, in your own fork of the repository:
     soon as your file has any translations (it doesn't have to be complete!).
     Before your pull-request can be accepted you need to agree to our
     [contributor
-    agreement](https://www.clahub.com/agreements/Coggle/translations), which
+    agreement](https://www.clahub.com/agreements/Coggle/coggle-translations), which
     gives us the necessary permissions to use your translations on the live
     site.
  


### PR DESCRIPTION
Signing the CLA on the previous link doesn't work any more.
Got the new link via email from The Coggle Team