### PR TITLE
Add new Belarusian translation

### DIFF
--- a/be.ftl
+++ b/be.ftl
@@ -1,0 +1,961 @@
+### Coggle translations for Belarusian
+#
+# For help with syntax email translations@coggle.it
+#
+# Translations now use Fluent https://projectfluent.org/fluent/guide/index.html
+#
+
+# frontpage content (https://coggle.it/home), except for the plans section
+# which is described below
+
+index-tagline = Зразумелы спосаб дзяліцца складанай інфармацыяй.
+index-tagline-mm = Стварайце майнд-карты, што плывуць, як вашы ідэі.
+index-signupnow = Зарэгістравацца зараз
+index-login = Ужо зарэгістраваліся? Увайдзіце тут.
+index-title = Coggle — магутныя майнд-карты і блок-схемы: супрацоўнічайце, занатуйце, плануйце, вучыцеся, генерыруйце ідэі.
+
+index-nav-login = Увайсці
+index-nav-pricing = Кошт
+index-nav-features = Функцыі
+index-nav-gallery = Галерэя
+index-nav-home = Галоўная
+
+index-unleash = Раскрыйце сваю творчасць
+index-blurb = Стварайце прыгожыя нататкі хутка і проста. Дзяліцеся імі з сябрамі і калегамі, каб разам працаваць над вашымі ідэямі.
+index-viewgallery = Ці зірніце на <a data-l10n-name='gallery'>галерэю Coggle</a> для натхнення.
+
+index-colab-mindmaps-flowcharts-h = Супольныя майнд-карты і блок-схемы
+index-colab-mindmaps-flowcharts-p1 = Coggle дазваляе лёгка ствараць і абменьвацца майнд-картамі і блок-схемамі. Ён працуе анлайн у вашым браўзеры: нічога не трэба спампоўваць або ўсталёўваць. <a data-l10n-name='login'>Увайдзіце</a>, каб пачаць ствараць дыяграмы ўжо цяпер!
+index-colab-mindmaps-flowcharts-p2 = Незалежна ад таго, робіце вы нататкі, праводзіце мазгавы штурм, плануеце ці займаецеся іншай творчай справай, з Coggle надзвычай проста візуалізаваць свае ідэі. Дзяліцеся імі з колькі заўгодна сябрамі ці калегамі. Змены, якія вы ўносіце, адразу з’явяцца ў іх браўзеры, дзе б яны ні былі ў свеце.
+
+index-use-notes-h = Вядзіце нататкі
+index-use-notes-p = Адкрыйце Coggle на сустрэчы, падчас падрыхтоўкі або дзе б вас ні наведала натхненне, каб стварыць прыгожыя, структураваныя нататкі.
+
+index-use-brainstorm-h = Мазгавы штурм
+index-use-brainstorm-p = Пачніце з зярнятка ідэі, паліце яго ў Coggle — і назірайце, як яно вырастае ў поўны план, ясна структураваны і гатовы да абмену.
+
+index-use-share-h = Абменьвайцеся інфармацыяй
+index-use-share-p = Вылучыце галоўнае ў патрэбнай тэме з Coggle, уключыце ўсе падрабязнасці і падзяліцеся рэзультатамі з камандай, аднакурснікамі або ўсім светам!
+
+index-coggle-flow-title = Магутныя анлайн-блок-схемы
+index-coggle-flow-description = Выкарыстоўвайце Coggle, каб адлюстроўваць свае працэсы, сістэмы і алгарытмы з дапамогай нашых новых магутных <a data-l10n-name='flowcharts'>інструментаў для блок-схем</a>.
+
+features-realtime = Супольная праца ў рэальным часе
+features-realtime-desc = Запрасіце сяброў і калег працаваць разам з вамі над вашымі дыяграмамі адначасова.
+
+features-unlimited-images-title = Неабмежаванае запампоўванне відарысаў
+features-images = Перацягвайце відарысы з працоўнага стала непасрэдна ў дыяграмы. Колькасць відарысаў не абмежаваная.
+
+features-fullhistory-title = Захоўванне ўсіх змен
+features-history = Праглядайце ўсе змены дыяграмы і стварайце копію з любога моманту, каб вярнуцца да папярэдняй версіі.
+
+features-labels-title = Дадавайце плаваючы тэкст і відарысы
+features-labels = Дадавайце тэкставыя меткі і відарысы, якія не ўваходзяць у дрэва дыяграмы, каб анатаваць часткі карты.
+
+features-blame-title = Адсочванне адказнасці
+features-blame = Праглядайце гісторыю дыяграмы, каб убачыць, хто, калі і што змяніў! Даведацца пра гэта можна ў рэжыме гісторыі.
+
+features-colours-title = Абярыце патрэбны колер
+features-colours = Націсніце на галіну, каб адкрыць каляровае кола і выбраць жаданы колер.
+
+features-notifications-title = Электронныя апавяшчэнні
+features-notifications = Атрымлівайце email-апавяшчэнні з аглядам змен, калі супрацоўнікі рэдагуюць абагуленыя з вамі дыяграмы.
+
+features-chat-title = Каментарыі і чат
+features-chat = Дадавайце каментарыі да вузлоў і размаўляйце з калегамі, не пакідаючы працоўную вобласць дыяграмы.
+
+
+# Plans selection translations (https://coggle.it/plans, when logged in, and
+# also on the homepage)
+plans-free-forever-title = Бясплатна назаўсёды
+plans-free-description = Ідэальна для знаёмства з Coggle і рэдкага выкарыстання.
+plans-free-price = Бясплатна назаўсёды
+
+feature-realtime = <b>Супольная праца</b> у рэальным часе
+feature-emoji = Больш за <b>1600</b> <a data-l10n-name="icons-link">прыгожых значкоў</a>
+feature-diagrams = <b>Неабмежаваныя</b> публічныя дыяграмы
+feature-nprivate =
+    { $privateDiagrams_available ->
+          [one] 1 прыватная дыяграма
+          [few] {$privateDiagrams_available} прыватныя дыяграмы
+       *[other] {$privateDiagrams_available} прыватных дыяграм
+    }
+feature-images = <b>Неабмежаванае</b> запампоўванне відарысаў
+feature-changes = <b>Поўная</b> гісторыя змен
+feature-markdown = Падтрымка <b>Markdown</b>
+feature-downloads = Спампоўванне ў фармаце <b>PDF і відарыса</b>
+feature-labels = Незвязаныя <b>тэкставыя блокі</b>
+feature-exports = Экспартаванне ў фармаце <b>.mm і тэксту</b>
+feature-visio = Экспартаванне для <b>Microsoft Visio</b>
+feature-imports = Імпартаванне <b>.mm і тэксту</b>
+feature-chat = Каментарыі і чат
+feature-embed = Убудавальныя дыяграмы
+feature-embed2 = Убудуйце майнд-карты дзе захочацца
+plans-free-getstarted = Пачаць
+
+plans-awesome-title = Awesome
+plans-awesome-description = Ідэальны для <b>асабістага</b> або <b>прафесійнага</b> выкарыстання з прыватнасцю і пашыранымі функцыямі.
+plans-awesome-price = $5 / месяц
+feature-include-free = Усё з <b>Бясплатнага</b> плана
+feature-unlimited-private = <b>Неабмежаваныя</b> прыватныя дыяграмы
+feature-shapes = <b>Больш форм элементаў</b>
+feature-multiroot = <b>Некалькі пунктаў пачатку</b>
+feature-chathistory = <b>Поўная</b> гісторыя чата
+feature-rearrange = <b>Аўтарасстаноўка</b> галін
+feature-rejoin = <b>Злучэнне</b> галін
+feature-folders = <b>Агульныя папкі</b>
+feature-presentation = Прэзентацыйны рэжым
+feature-bigimages = <b>Высакаякаснае</b> запампоўванне відарысаў
+feature-linestyles = <b>Кіраванне стылямі ліній</b>
+feature-controlpoints = <b>Кіраванне траекторыямі ліній</b>
+feature-textalign = Змена <b>выраўноўвання тэксту</b>
+feature-extendedcolours = Больш колераў
+feature-editable-links = Супрацоўніцтва па <b>спасылцы</b>
+plans-findoutmore = Даведацца больш
+
+plans-org-title = Organization
+plans-org-description = Ідэальны для <b>каманд</b>, якія хочуць кантраляваць доступ да сваіх даных і мець аб’яднаныя рахункі.
+plans-org-price = $8 / карыстальнік / месяц
+feature-org-awesome = Усе функцыі плана <b>Awesome</b>
+feature-org-separate = Асобная асабістая прастора
+feature-org-billing = Выстаўленне аб’яднаных рахункаў
+feature-bulkexport = <b>Масавы экспарт</b>
+feature-adminpanel = <b>Кіраванне карыстальнікамі і данымі</b>
+feature-branding = Брэндзіраванне дыяграм
+feature-org-saml-sso = SAML Single Sign On
+
+plans-select = Выбраць
+continue-free = Працягнуць з <b>Бясплатным</b> планам
+current-plan = Ваш бягучы план
+cancel-subscription = Скасаваць падпіску
+awesome-signup-monthly = Аформіць <span>$5</span> у месяц
+awesome-signup-yearly = Аформіць <span>$50</span> у год
+awesome-upgrade-monthly = Палепшыць (<b>$5</b>/месяц)
+awesome-upgrade-yearly = Палепшыць (<b>$50</b>/год)
+yearly-discount = Зэканомце $10 пры штогадовай аплаце
+switch-yearly = Абнавіць да штогадовай
+manage-subscription = Кіраваць падпіскай
+
+per-month = у месяц
+per-member-per-month = за карыстальніка ў месяц
+forever = назаўсёды
+flexible = поўная гнуткасць
+
+awesome-feature = План Awesome
+org-feature = Функцыя плана Organization
+
+footer-help = Дапамога і дакументацыя
+footer-about = Пра нас
+footer-contact = Кантакты
+footer-privacy = Прыватнасць
+footer-examples = Шаблоны і прыклады
+footer-api = API для распрацоўшчыкаў
+footer-blog = Bloggle
+footer-terms = Умовы
+footer-press = Прэса
+footer-what-is-mindmapping = Што такое майндмэпінг?
+footer-top-uses = Найлепшыя выкарыстанні майнд-карт
+footer-company = Кампанія
+footer-legal = Прававыя звесткі
+footer-access = Даступнасць
+
+# logged-in homepage content (documents list): https://coggle.it when logged in
+create-diagram-2-allowed = <span data-l10n-name='icon'></span> <span data-l10n-name='label'>Стварыць дыяграму</span>
+    .title = Стварыць дыяграму Coggle
+create-diagram-2-nothere = <span data-l10n-name='icon'></span> <span data-l10n-name='label'>Стварыць дыяграму</span>
+    .title = Вы не можаце тут ствараць новыя дыяграмы, спачатку абярыце іншую папку.
+search-diagrams =
+    .placeholder = Шукайце свае дыяграмы
+search-public-diagrams = 
+    .placeholder = Шукайце публічныя дыяграмы
+view-gallery = Галерэя
+create-folder = Стварыць папку
+shared-folders = Агульныя папкі
+created-by-you =
+    .value = Створана вамі
+shared-with-you =
+    .value = Падзялілі з вамі
+folder-title =
+    .placeholder = Увядзіце назву папкі
+    .value = { $name }
+folder-areyousure = Вы ўпэўнены?
+folder-sure = Я ўпэўнены
+logout = Выйсці
+settings = Налады
+return-to-diagrams = Вярнуцца да дыяграм
+upgrade-to-awesome = Палепшыць да плана <b>Awesome</b>!
+# the <time></time> element is replaced with a translated string like "15 days from now", "1 month from now" etc.:
+awesome-time-remaining = Пробны перыяд плана Awesome скончыцца праз <time data-l10n-name="remaining"></time>
+awesome-trial-after = Пасля вас перавядуць на бясплатны план
+want-awesome-for-free = Хочаце карыстацца Awesome бясплатна?
+help-search =
+    .placeholder = Дапамажыце мне…
+my-settings = Мае налады і выстаўленне рахункаў
+my-settings-only = Мае налады
+org-settings =
+    .title = Кіраванне арганізацыяй
+org-admin = Адміністратар арганізацыі {$orgName}
+user-about = Пра Coggle
+user-contact = Звяжыцеся з намі
+user-privacy = Палітыка прыватнасці
+user-terms = Умовы выкарыстання
+user-link-drive = Прывязаць Google Drive
+diagrams-limited = Выкарыстана <span data-l10n-name="count">{ $privateDiagrams_used } з { $privateDiagrams_available }</span> прыватных дыяграм
+diagrams-unlimited = <span data-l10n-name="count">Неабмежаваная колькасць</span> прыватных дыяграм
+
+limitedaccess = У вас абмежаваны доступ да { $resourceName }, бо вы не з’яўляецеся ўдзельнікам
+doclist-create = <b>Сардэчна запрашаем у Coggle!</b> — тут будуць адлюстроўвацца створаныя вамі дыяграмы.
+
+doclist-shared = <b>Падзялілі з вамі</b> — дыяграмы, створаныя іншымі і падзеленыя з вамі, адлюстроўваюцца тут.
+doclist-folder-empty = <b>Гэтая папка пустая!</b> — Стварыце новую дыяграму або перацягніце існыя ў гэту папку.
+doclist-folder-recent = <b>Нядаўна абноўленыя дыяграмы</b> — Дыяграмы з любых вашых папак, змененыя за апошні месяц, з’явяцца тут.
+doclist-readonly = <b>Сардэчна запрашаем у Coggle!</b> — Папрасіце ўладальніка даць вам доступ для стварэння дыяграм тут.
+impersonatedaccess = Вы праглядаеце Coggle як удзельнік арганізацыі. <a data-l10n-name='back'>Вярнуцца да панэлі адміністратара</a>
+
+doclist-loading-failed = Ой! Не ўдалося загрузіць папку, абнавіце старонку і паспрабуйце зноў.
+doclist-discover-whatspossible = Хочаце атрымаць больш ад Coggle? Даведайцеся <a data-l10n-name='link'>што магчыма</a>.
+
+sort-custom = Уласны парадак
+sort-a-z = А–Я
+sort-z-a = Я–А
+sort-newest-asc = Спачатку самыя новыя
+sort-newest-desc = Спачатку найстарэйшыя
+sort-modified-asc = Спачатку нядаўна змененыя
+sort-modified-desc = Спачатку самыя даўнія змены
+
+tooltip-createorg =
+    .title = Стварыць арганізацыю
+tooltip-invite-folder =
+    .title = Дадаць людзей у папку па email
+tooltip-invite =
+    .title = Запрасіць людзей далучыцца да Coggle
+tooltip-private-icon =
+    .title = Дыяграма прыватная
+tooltip-unsubscribe =
+    .title = Адпісацца ад апавяшчэнняў
+tooltip-subscribe =
+    .title = Падпісацца на апавяшчэнні
+tooltip-duplicate =
+    .title = Стварыць копію
+tooltip-remove =
+    .title = Выдаліць дыяграму
+tooltip-restore =
+    .title = Аднавіць дыяграму
+tooltip-more =
+    .title = Параметры дыяграмы
+
+# documents list contextual help items 
+help-searchcoggle-title = Пошук па Coggle
+help-searchcoggle = Уводзьце тэкст для хуткага пошуку любога слова ў дыяграме!
+help-hide-for-now = Схаваць цяпер
+help-ok-got-it = ОК, зразумела!
+help-creatediagram-title = Стварыць новую дыяграму
+help-creatediagram = Стварыце новую дыяграму Coggle, каб пачаць.
+
+help-createfolder-title = Стварыць папку
+help-createfolder = Стварыце папкі для сумеснага доступу або каб класіфікаваць дыяграмы.
+
+help-orgs-switch-title = Пераключэнне паміж арганізацыямі
+help-orgs-switch-p1 = Націсніце, каб пераключыцца паміж арганізацыямі.
+help-orgs-switch-p2 = Арганізацыі дазваляюць кантраляваць доступ і працаваць з вялікімі камандамі.
+
+
+# Settings page content 
+settings-plans-title = Планы
+settings-billing-title = Аплата і рахункі
+settings-recommend-title = Рэкамендацыі
+settings-emails-title = Камунікацыя
+settings-language-title = Мова
+settings-communication-title = Камунікацыя
+settings-account-title = Закрыць уліковы запіс
+settings-profile-title = Профіль
+settings-membership-title = Удзельнікі
+settings-exports-title = Экспарт
+settings-authentication-title = Аўтэнтыфікацыя
+
+billing-card = Картка ў базе сканчваецца на <b>{ $cardEndsIn }</b>, тэрмін дзеяння — <b>{ $cardExpires }</b>.
+billing-addr = Паштовы індэкс для аплаты: <b>{ $addressZip }</b>. <a data-l10n-name="edit">Рэдагаваць даныя карткі</a>
+
+billing-remove = Выдаліць
+billing-nocard = У вашым уліковым запісе няма метадаў аплаты. <a data-l10n-name='setup-card'>Наладзіць даныя карткі</a>
+
+summary-free-plan = У вас яшчэ няма падпіскі. <a data-l10n-name="subscribe">Атрымаць цяпер!</a>
+summary-active-plan = Вы карыстаецеся планам <code>{ $planName }</code>. <a data-l10n-name="cancel">Скасаваць падпіску</a> або <a data-l10n-name="compare">параўнаць планы</a>.
+summary-uy-1 = Атрымайце два месяцы бясплатна (<b>зэканомце 15%</b>) пры гадавой аплаце. <a data-l10n-name="upgrade">Абнавіць (<b>$50</b>)</a>
+summary-uy-2 = Час, які застаўся на бягучым плане, аўтаматычна будзе адняты ад кошту абнаўлення.
+summary-uy-c1 = Пацвердзіць абнаўленне? Мы спішам з вашай карткі суму ад $45 да $50 у залежнасці ад астатняга часу на штогадовым плане. Дата наступнага плацяжу — праз год.
+summary-confirm = Пацвердзіць абнаўленне
+summary-ending-2 = Вы скасавалі падпіску на план <code>{$planName}</code> і вас больш не будуць спісваць. Вы можаце карыстацца платнымі функцыямі да канца ўжо аплачанага перыяду.<br> <a data-l10n-name='resub'>Паўторна падпісацца</a>
+summary-overdue-plan = Ваша падпіска неактыўная з-за прамаруджанага плацяжу. Каб вырашыць гэта, абнавіце картку або звяжыцеся з намі па <b>hello@coggle.it</b>.
+complete-payment = Вы можаце <a data-l10n-name='invoice-link'>праглядзець і завяршыць</a> непагашаны плацеж або <a data-l10n-name='cancel'>скасаваць падпіску</a>.
+
+me-communication-title = Камунікацыя
+me-emails-title = Адрасы электроннай пошты
+me-emails-primary = (асноўны)
+me-emailstip = Пошта будзе адпраўляцца толькі на асноўны адрас, але вы можаце атрымліваць запрашэнні на любы з астатніх.
+me-talktome = Размаўляйце са мной:
+me-diagram-notifications = Апавяшчэнні пра дыяграмы:
+
+slider-yes = ТАК
+slider-no = НЕ
+
+me-language-title = Выбар мовы
+me-language-tip = Дапамажыце нам забяспечыць Coggle на вашай роднай мове або дадаць тое, чаго не хапае, праз удзел у нашым <a data-l10n-name='translate-link'>праекце перакладаў</a> на GitHub!
+me-language-questions = Калі ў вас ёсць пытанні адносна перакладаў — ці вы маеце выпраўленні і не ведаеце, як дапамагчы, напішыце нам на <a data-l10n-name='translate-email'>translate@coggle.it</a>.
+
+profile-title = Ваша знешнасць у Coggle
+
+invite-n-more =
+    { $introduceCount ->
+           [one] Яшчэ адно запрашэнне, каб паспрабаваць Awesome бясплатна!
+        *[other] Запрасіце яшчэ <span>{$introduceCount}</span> чалавек, каб паспрабаваць Awesome бясплатна!
+    }
+
+recommend-coggle = Парэкамендуйце Coggle
+recommend-share-link = Запрасіце супрацоўнікаў або падзяліцеся сваёй рэферальнай спасылкай па <a data-l10n-name='email'>email</a>.
+
+claim-free-month = Атрымайце бясплатны месяц Coggle Awesome!
+claim-redeem = Выкарыстоўваць цяпер
+
+
+close-account-title = Закрыць ваш уліковы запіс Coggle
+close-account = Выдаліць ваш бясплатны ўліковы запіс Coggle назаўсёды.
+close-account-description = Гэты працэс <b>неадваротны</b> і ўступіць у сілу адразу. Вы страціце доступ да ўсіх дыяграм, таму пераканайцеся, што экспартавалі тыя, якія хочаце захаваць.
+close-account-button = Закрыць мой уліковы запіс
+close-account-enteremail =
+    .placeholder = Увядзіце ваш email
+close-account-confirm = ПАЦВЯРДЗІЦЬ
+
+# Gallery Content (/gallery) 
+gallery-title = Галерэя Coggle
+gallery-blurb2 = Выбар лепшых дыяграм, створаных у Coggle!
+gallery-blurb3 = Знайдзіце натхненне, шаблоны і прыклады сярод нашых найлепшых публічных дыяграм і майнд-карт.
+gallery-folder-blurb3 = <b>Галерэя Coggle</b> — Выбар найлепшых дыяграм, створаных у Coggle!
+
+
+# Diagram content 
+guide-click-here = націсніце тут
+guide-or-here = або тут
+click-to-edit = націсніце, каб рэдагаваць
+click-to-edit-title = Націсніце, каб рэдагаваць загаловак
+tap-to-edit = дакраніцеся, каб рэдагаваць
+tap-to-edit-title = Дакраніцеся, каб рэдагаваць загаловак
+unnamed-diagram = Дыяграма без назвы
+
+add-branch = дадаць галіну
+copy-branch = скапіяваць галіну
+add-to-discussion = дадаць у абмеркаванне
+comment-on-this = пакінуць каментарый
+auto-arrange = аўтарасстаноўка
+pick-colour = выбраць колер
+choose-style = выбраць стыль
+choose-shape = выбраць форму
+
+# (remove and item *and* all of its children)
+delete-branch = выдаліць галіну
+
+remove-item = выдаліць элемент
+show-children = паказаць падпункты
+hide-children = схаваць падпункты
+drag-to-create-link = перацягніце, каб звязаць
+drag-to-transplant-branch = перацягніце, каб перасадзіць галіну
+delete-connection = выдаліць злучэнне
+reverse-connection = адвярнуць кірунак злучэння
+label-connection = падпісаць злучэнне
+move-branch-to-diagram = перанесці галіну ў новую дыяграму
+copy-branch-to-diagram = скапіяваць галіну ў новую дыяграму
+
+undo = адрабіць
+redo = паўтарыць
+paste-branch = уставіць галіну
+drag-zoom-page = перацягвайце, каб маштабіраваць старонку
+add-label = дадаць метку
+
+help-title-title = Загаловак дыяграмы
+help-title-p1 = Гэта цэнтр вашай дыяграмы і яе загаловак. Адсюль будуць разыходзіцца вашы ідэі!
+help-title-p2 = Пачніце рэдагаванне — пра што ваша дыяграма?
+help-gohome-2 = Калі вы скончылі рэдагаваць, націсніце на лагатып, каб вярнуцца на галоўную старонку. Вашы дакументы захоўваюцца аўтаматычна.
+help-add-node = Выкарыстоўвайце кнопкі <div data-l10n-name='plus'>+</div> для дадавання галін.
+help-edit-node-p1 = Націсніце на любы элемент, каб рэдагаваць тэкст.
+help-edit-node-p2 = Змяняйце памер тэксту, перацягваючы вугал вобласці рэдагавання.
+help-move-node = Перацягвайце тэкст, каб перамясціць яго.
+help-node-menu = Націсніце правай кнопкай на элемент, каб адкрыць меню. Тут вы можаце дадаваць, выдаляць, капіяваць і ўпарадкоўваць галіны.
+help-morehelp-touch-title = Хуткія каманды і дапамога
+help-morehelp2-title = Спалучэнні клавіш і дапамога
+help-morehelp-touch = Адкрыйце дапаможны аркуш, каб убачыць хуткія каманды і хутка шукаць дапаможныя артыкулы
+help-morehelp2 = Адкрыйце дапаможны ліст, каб убачыць спалучэнні клавіш і хутка шукаць дапаможныя артыкулы
+
+help-multiline = Дадавайце некалькі радкоў тэксту, выкарыстоўваючы [ctrl] + [enter] або перацягнуўшы ручку змены памеру перад наборам.
+help-toolbar-invite-title = Супрацоўніцтва з іншымі
+help-toolbar-invite = Націсніце, каб запрасіць людзей рэдагаваць або праглядаць гэты Coggle. Вы можаце кіраваць іх дазволамі, націснуўшы на іх аватар.
+help-toolbar-invitemulti-title = Запрасіць некалькіх людзей
+help-toolbar-invitemulti = Каб зэканоміць час, вы можаце адначасова запрасіць некалькіх людзей: увядзіце (ці ўстаўце) адрасы электроннай пошты, раздзяляючы іх прабеламі, коскамі<b>,</b> або кропкамі з коскай<b>;</b>
+
+help-toolbar-invitedonefaster-p1 = Вы ўжо некаторы час рэдагуеце – паспрабуйце рабіць яшчэ хутчэй з дапамогай сумеснай працы!
+help-toolbar-invitedonefaster-p2 = Запрасіце калег рэдагаваць разам з вамі і адразу бачыце іх змены.
+help-toolbar-inviteflow-title-2 = Запрасіць калегу па электроннай пошце
+help-toolbar-sharing-title = Спасылкі для сумеснага доступу і публікацыі
+help-toolbar-sharing = Вы таксама можаце апублікаваць сваю дыяграму ці стварыць сакрэтныя спасылкі, якія даюць доступ толькі тым, хто мае гэтую спасылку.
+help-inactive-invite = Працуйце з сябрамі, каб ажывіць вашы ідэі!<br>Запрасіце па электроннай пошце тут.
+
+me-as-awesome-orgmember-p1 = Гэта вы &mdash; вы праглядаеце Coggle як <b>удзельнік арганізацыі</b>.
+me-as-awesome-orgmember-p2 = Гэта значыць, вы таксама маеце ўсе выдатныя функцыі плана <a data-l10n-name="awesome">Coggle Awesome</a>!
+
+free-awesome = Хочаце атрымаць Awesome бясплатна?
+upgrade-now = Абнавіць зараз
+
+me-support-awesomethanks-p1 = <b>Дзякуем за падтрымку Coggle!</b>
+me-support-awesomethanks-p2 = За тое, што вы адзін з ранніх прыхільнікаў Coggle, усе перавагі плана <a data-l10n-name="awesome">Coggle Awesome</a> уключаны ў вашу падпіску!
+
+me-awesome = Гэта вы &mdash;<b>Вы цудоўныя!</b>
+me-manage-plan = Кіраваць вашым планам
+
+
+messages-title = Паведамленні
+messages-search =
+    .placeholder = Пошук
+messages-start = Вы дасягнулі пачатку!
+messages-comments-notes =
+    .placeholder = Увядзіце каментарыі, абмеркаванні і нататкі.
+
+
+diagram-toolbar-history =
+    .title = Прагляд і капіяванне папярэдніх версій.
+diagram-toolbar-messages =
+    .title = Каментарыі і чат.
+diagram-toolbar-present =
+    .title = Рэжым прэзентацыі і агляд.
+diagram-toolbar-share =
+    .title = Падзяліцца гэтым Coggle.
+diagram-toolbar-download =
+    .title = Спампаваць гэты Coggle.
+diagram-toolbar-copy =
+    .title = Стварыць копію гэтага Coggle.
+diagram-toolbar-public-detail = Публічная дыяграма
+    .title = Гэты дыяграма можа з’яўляцца ў Галерэі Coggle і выніках пошуку.
+diagram-toolbar-pubcopy = Выкарыстоўваць як шаблон
+    .title = Стварыць уласную копію гэтай дыяграмы.
+public-label = Публічная
+    .title = Гэта публічная дыяграма.
+
+# history slider content 
+current-version = цяперашняя
+
+# sharing dialog content 
+share-newlink = Новая спасылка:
+share-newlink-tip = Яны дазваляюць дзяліцца дыяграмай з людзьмі без уваходу, але асцярожна — любы, у каго ёсць спасылка, можа бачыць вашу працу!
+
+share-tag-user = карыстальнік
+share-tag-embed = убудова
+share-tag-writable = рэдагавальны
+share-send-email = АДПРАВІЦЬ
+share-email-hints =
+  <span>каб запрасіць, увядзіце email</span>
+  <span>затым націсніце Enter</span>
+  <span>friend@example.com</span>
+
+viewers-can-edit = 
+    .title = Гледачы могуць рэдагаваць дыяграму.
+viewers-readonly =
+    .title = Гледачы могуць толькі праглядаць дыяграму.
+viewers-can-copy =
+    .title = Гледачы могуць ствараць уласныя копіі.
+viewers-nocopy = 
+    .title = Гледачы не могуць ствараць копіі.
+revoke-link = 
+    .title = Выдаліць гэту спасылку.
+
+share-open = Ці можа кожны праглядаць гэтую дыяграму?
+share-open-detail = Публічныя дыяграмы могуць праглядацца любым, і яны могуць з’яўляецца ў нашай <a data-l10n-name="gallery">Галерэі</a>
+
+# download dialog content 
+download-pdf = Спампаваць PDF
+download-png = Спампаваць відарыс
+download-mm = .mm-файл
+download-txt = Звычайны тэкставы файл
+download-visio = Блок-схема Visio (.vsdx) 
+download-failed = Не ўдалося стварыць файл.
+    .title = Націсніце для паўторнай спробы
+download-import-tip = <b>Хочаце нешта імпартаваць?</b> Перацягніце .mm або .txt-файл на дыяграму для імпартавання! <a data-l10n-name="import-link">Даведайцеся больш</a>.
+
+# access control slider content 
+access-readonly = Толькі прагляд<br/><span data-l10n-name="tip">Дазволіць толькі прагляд</span>
+access-readclone = Прагляд і копіі<br/><span data-l10n-name="tip">Таксама дазволіць загрузку і капіяванне</span>
+access-author = Аўтар<br/><span data-l10n-name="tip">Дазволіць ствараць і рэдагаваць дакументы</span>
+
+access-folder-readonly = Толькі прагляд<br/><span data-l10n-name="tip">Дазволіць толькі прагляд</span>
+access-folder-readclone = Прагляд і копіі<br/><span data-l10n-name="tip">Таксама дазволіць загрузку і капіяванне</span>
+access-folder-author = Аўтар<br/><span data-l10n-name="tip">Дазволіць ствараць і рэдагаваць дакументы</span>
+access-folder-admin = Адміністраванне<br/><span data-l10n-name="tip">Дадаваць і выдаляць людзей і дакументы</span>
+
+access-remove = Выдаліць { $user_givenName }
+
+# Notification Messages 
+readonly-warning = Вы не можаце рэдагаваць гэтую дыяграму. <div data-l10n-name="suggestion">Калі вам трэба рэдагаваць, папрасіце аўтара даць вам дазвол.</div>
+
+websocket-offline = Змены ў сапраўдным часе недаступная з-за сеткі. <a data-l10n-name='helpfix'>Больш інфармацыі</a>
+
+disconnect-warning = <b>Злучэнне страчана</b>: Змены могуць не захавацца
+
+banner-undo-warning = Няма чаго адрабляць!
+banner-redo-warning = Няма чаго аднаўляць!
+
+# Image drag-drop messages 
+image-resize-plug = Ваш відарыс зменшаны — атрымайце <a data-l10n-name='awesome'>Awesome</a>, каб загружаць вялікія відарысы!
+
+# Help panel
+sidebar-contextmenu = Кантэкстнае меню
+sidebar-clickformenu = Націсніце правай кнопкай па элеменце ці фоне для доступу да меню.
+sidebar-tapformenu = Дакраніцеся да элемента ці фону для доступу да меню.
+sidebar-controls = Элементы кіравання
+
+sidebar-removebranch = Выдаліць галіну:
+sidebar-insertbranch = Уставіць галіну:
+sidebar-transplantbranch = Перасадзіць галіну:
+sidebar-addimages-title = Дадаць <a data-l10n-name='images'>відарысы</a>:
+
+sidebar-zoom = Маштаб:
+
+sidebar-shortcuts = Спалучэнні клавіш
+sidebar-undo = Адрабіць:
+sidebar-redo = Аднавіць:
+
+touch-pressitem = <b>Доўгае націсканне</b> на <b>элемент</b> дазваляе <b>выдаляць</b> элементы, змяняць іх <b>колер</b>, рабіць аўтарасстаноўку, крос-спасылкі, капіяваць элементы і інш.
+touch-pressbackground = <b>Доўгае націсканне</b> на <b>фоне</b> дазваляе дадаваць <b>меткі</b>, <b>адрабляць</b> дзеянні і ўстаўляць змесціва.
+
+sc-and-click = + націсканне
+sc-and-drag = + перацягванне
+sc-and-mousewheel = + колца мышы
+sc-shift = shift ⇧
+sc-ret = enter ⏎
+sc-tab = tab ⇥
+sc-ctrl = ctrl ^
+sc-alt = alt
+sc-option = option ⌥
+sc-dragdrop = перацягнуць і адпусціць
+
+sidebar-whentyping = Пры наборы тэксту
+sidebar-sc-newitem = Новы элемент:
+
+sidebar-sc-newchild = Новы даччыны элемент:
+
+sidebar-sc-parent = Перайсці да бацькі:
+
+sidebar-sc-markdown-title = Фарматаванне тэксту:
+sidebar-sc-markdown = выкарыстоўваць <a data-l10n-name="link">Markdown</a>
+
+hint-control-line = Перацягвайце, каб рэгуляваць лінію.
+hint-control-remove = Націсніце, каб выдаліць пункт кіравання.
+hint-delete-link = Выдаліць крос-спасылку.
+hint-edit-label = Рэдагаваць подпіс крос-спасылкі.
+hint-add-title = Дадаць новую галіну — гэта загаловак дыяграмы.
+hint-add =
+    {
+        $os ->
+            [Mac] Дадаць новую галіну. Каб выдаліць замест гэтага, выкарыстоўвайце <kb-key data-l10n-name="delete-key">{sc-option}</kb-key>, або для таго, каб уставіць — <kb-key data-l10n-name="insert-key">{sc-shift}</kb-key>.
+           *[Win] Дадаць новую галіну. Каб выдаліць замест гэтага, выкарыстоўвайце <kb-key data-l10n-name="delete-key">{sc-ctrl}</kb-key>, або для таго, каб уставіць — <kb-key data-l10n-name="insert-key">{sc-shift}</kb-key>.
+    }
+hint-delete = Выдаліць галіну.
+hint-remove = Выдаліць элемент.
+hint-insert-rp = Уставіць элемент перад гэтым або перацягнуць, каб перасадзіць галіну.
+
+
+stat-saving = Захоўваецца
+stat-saved = Усе змены захаваны
+stat-noaccess = Доступ забаронены
+
+another-fact = яшчэ нешта!
+cogglefacts-more = Чытаць далей…
+
+sidebar-markdown = Markdown
+sidebar-bgmenu = <b>Маштабіраванне</b>, <b>адмена</b> і <b>ўстаўка скапіяваных элементаў</b> — націсніце правай кнопкай па фоне.
+sidebar-bgmenu2 = <b>Маштабіраванне</b>, дадаць <b>тэкставыя меткі</b>, <b>адмена</b> і <b>ўстаўка скапіяваных элементаў</b> — націсніце правай кнопкай па фоне.
+sidebar-icons = Значкі
+markdown-icons = Уводзьце тэкст <code>:</code> падчас рэдагавання або выкарыстоўвайце кнопку ў верхняй частцы рэдактара элемента.
+markdown-checkbox = <code>- [X]</code> для стварэння <input data-l10n-name="checkbox"/> поля выбару
+markdown-code = <code>`text`</code> каб выкарыстоўваць шрыфт фіксаванай шырыні
+
+button-bold =
+    .title = Зрабіць тэкст тлустым
+button-italic =
+    .title = Зрабіць тэкст курсіўным
+button-link =
+    .title = Стварыць спасылку на вэб-сайт
+button-image =
+    .title = Запампаваць відарыс
+button-emoji =
+    .title = Шукаць значкі
+button-formatting =
+    .title = Фарматаванне тэксту
+button-back =
+    .title = Назад
+button-aligned-left =
+    .title = Выраўнаваць па левым краі
+button-aligned-center =
+    .title = Пасярэдзіне
+button-aligned-right =
+    .title = Выраўнаваць па правым краі
+button-aligned-auto =
+    .title = Аўтаматычнае выраўноўванне
+button-upload =
+    .title = Дадаць відарыс або прымацаваць файл
+button-attach =
+    .title = Прымацаваць файл
+button-resize =
+    .title = Цягнуць, каб змяніць памер тэксту
+label-fontsize = Памер шрыфта <span data-l10n-name="fontsize"></span>px.
+
+hint-toolong = Элемент занадта доўгі! Паспрабуйце перанесці частку тэксту ў новы элемент: абярыце тэкст і націсніце [tab]
+hint-movetext = Паспрабуйце перанесці частку тэксту ў новы элемент: абярыце тэкст і націсніце [tab]
+
+commentcount =
+    { $count ->
+        [one] 1 каментарый
+        [few] { $count } каментарыі
+       *[other] { $count } каментарыяў
+    }
+
+# diagram not-found page 
+nodiagram-title = Дыяграма не знойдзена!
+nodiagram-invalid-link = Гэта спасылка на дыяграму несапраўдная альбо доступ да яе адкліканы.
+nodiagram-logged-in = Вы зараз увайшлі як <b>{ $user_givenName }</b> з адрасам электроннай пошты <b>{ $user_email }</b>. Калі такая дыяграма існуе, гэтаму ўліковаму запісу не прадастаўлены доступ.
+nodiagram-not-logged-in = <b>Вы не ўвайшлі ў сістэму.</b> Калі гэтая дыяграма існуе, вы можаце атрымаць доступ, калі ўвойдзеце ў свой уліковы запіс.
+nodiagram-may-need-access = Калі нехта даслаў вам спасылку на гэтую дыяграму, магчыма, вам таксама трэба будзе папрасіць даць дазвол на прагляд.
+
+
+# Awesome Landing Page (/awesome) 
+awesome-pitch-title = Coggle Awesome
+awesome-pitch = Пачуйце новы ўзровень думання з Coggle Awesome. Дадавайце велізарныя відарысы, прэзентуйце свае дыяграмы і стварайце прыватныя дыяграмы, якія не будуць індэксавацца пошукавымі сістэмамі.
+awesome-signup = ЗАРЭГІСТРАВАЦЦА ЗАРАЗ
+awesome-price = ${$monthlyPrice} / МЕСЯЦ
+
+awesome-feature-cp-title = Кіраванне траекторыямі злучэнняў
+awesome-feature-cp = Размяшчайце злучэнні дакладна там, дзе трэба, з дапамогай кропак кіравання на шляхах галін.
+
+awesome-feature-shapes-title = Пашыраныя формы элементаў
+awesome-feature-shapes = Наладжвайце блок-схемы з дапамогай усіх даступных формаў элементаў. Выкарыстоўвайце ромбы для вузлоў рашэнняў, а тэкст размяшчайце па лініі злучэнняў для арганізацыйных дыяграм.
+
+awesome-feature-private-title = Неабмежаваныя прыватныя дыяграмы
+awesome-feature-private = Стварайце столькі прыватных дыяграм, колькі пажадаеце. Калі вы скасуеце падпіску, яны застануцца прыватнымі, і вы захаваеце доступ.
+
+awesome-feature-joinloop-title = Стварэнне цыклаў і злучэнне галін
+awesome-feature-joinloop = Злучайце галіны і стварайце цыклы, каб ствараць больш магутныя і гнуткія дыяграмы, якія адлюстроўваюць патокі працэсаў і іншыя складаныя структуры.
+
+awesome-feature-multiroot-title = Некалькі пунктаў пачатку
+awesome-feature-multiroot = Дадавайце некалькі цэнтральных элементаў у дыяграму, каб адлюстроўваць звязаныя тэмы ў адным працоўным асяроддзі.
+
+awesome-feature-editablelinks-title = Супрацоўніцтва без налад
+awesome-feature-editablelinks = Дазваляйце неабмежаванай колькасці людзей рэдагаваць дыяграму проста па сакрэтнай спасылцы. Уваход у сістэму не патрабуецца.
+
+awesome-feature-linestyle-title = Кіраванне стылем ліній
+awesome-feature-linestyle = Наладжвайце таўшчыню і стыль ліній у дыяграме.
+
+awesome-feature-bigimages-title = Пакажыце вялікую карціну
+awesome-feature-bigimages = Дадавайце велізарныя відарысы ў дыяграмы, каб ілюстраваць свае ідэі: проста перацягніце відарыс з працоўнага стала на дакумент.
+
+awesome-feature-colours-title = Больш колераў
+awesome-feature-colours = Адкрыйце новы спектр яркіх колераў, каб арганізаваць і вылучыць вашы ідэі.
+
+awesome-feature-autoarrange-title = Аўтаматычнае размяшчэнне галін
+awesome-feature-autoarrange = Ачысціце размяшчэнне галін адным націсканнем з дапамогай функцыі аўтаматычнага выраўноўвання галін у Coggle Awesome.
+
+awesome-feature-folders-title = Агульныя папкі
+awesome-feature-folders = Размяшчайце дыяграмы ў папках, каб захоўваць іх структураванымі і лёгка дзяліцца з групай калег.
+
+awesome-feature-flow-title = Магутнае стварэнне блок-схем
+awesome-feature-flow = Выбірайце з мноства форм для стварэння выразных, магутных блок-схем, карт працэсаў і іншых дыяграм.
+
+awesome-hint-orgs = 
+  Калі вы выкарыстоўваеце Coggle на працы, азнаёмцеся з <a data-l10n-name="orglink">Coggle-арганізацыямі</a>, якія ўключаюць усе перавагі плана Coggle Awesome і бізнес-арыентаваныя функцыі адміністратара.
+
+
+# Login Page /login
+index-loginwithgoogle = Увайсці праз Google
+index-signinwithapple = Увайсці праз Apple
+
+login-no-acc-q = У вас няма ўліковага запісу Google або Microsoft?
+login-no-acc-a = Нічога страшнага! Вы можаце стварыць уліковы запіс Google або Microsoft з любой электроннай поштай. Уліковы запіс Gmail або Outlook <b>не</b> абавязковы.
+
+login-saml = Мы таксама падтрымліваем карпаратыўны ўваход для Coggle-арганізацый праз OneLogin, Okta і іншых пастаўшчыкоў SAML 2.0.
+login-saml-where = Калі вы выкарыстоўваеце адзіны ўваход, увайдзіце з дапамогай старонкі, якую падаў адміністратар вашай арганізацыі.
+login-saml-more = Больш пра Single Sign-On.
+
+login-faq = Часта задаваныя пытанні
+login-pw-q = Чаму я не магу стварыць імя карыстальніка і пароль?
+login-pw-a-p1 = Coggle падтрымлівае толькі ўваход праз Google, Microsoft або
+    Apple. Мы лічым, што гэта лепшы спосаб абараніць вашы даныя, бо гэтыя сэрвісы
+    прапануюць надзейную аўтэнтыфікацыю, уключаючы двухфактарную праверку.
+
+login-pw-a-p2 = Бяспечнае захоўванне імёнаў карыстальнікаў і пароляў патрабуе
+    складаных механізмаў: аднаўленне пароля, двухфактарная аўтэнтыфікацыя,
+    выяўленне махлярства, абарона ад грубай сілы і бяспечнае захоўванне
+    захэшыраваных пароляў. Мы лічым, што лепш перадаць гэтыя задачы знешняму
+    пастаўшчыку, каб накіраваць усе сілы на стварэнне выдатнага інструмента для мыслення.
+
+login-what-q = Што вы робіце з маім уліковым запісам Google/Microsoft?
+login-what-a = Мы запытваем толькі доступ да асноўнай інфармацыі профілю:
+    імя, фота і адрас электроннай пошты. Мы не просім доступ да кантактаў,
+    лістоў, дакументаў Google Drive ці іншых даных, якія не патрэбныя для
+    працы Coggle.
+
+login-switch-q = Ці магу я пераключацца паміж спосабамі ўваходу?
+login-switch-a = Так! Калі вы выкарыстоўваеце аднолькавы адрас электроннай пошты ў Google, Microsoft або Apple,
+    вы можаце ўваходзіць любым з іх у той жа ўліковы запіс. Заўважце,
+    што выбар опцыі «схаваць мой email» ў Apple зробіць звязванне ўліковых запісаў немагчымым.
+
+login-emails-q = Ці чытаеце вы мае лісты?
+login-emails-a = Не. Мы не патрэбны і не жадаем доступу да вашых лістоў!
+    Мы запытваем толькі асноўную інфармацыю профілю. Мы не маем доступу да чагосьці яшчэ,
+    і не можам змяняць налады вашага ўліковага запісу Google/Microsoft.
+
+login-icloud-q = Ці маеце вы доступ да майго iCloud?
+login-icloud-a = Не! Уваход праз Apple дае нам толькі імя і адрас электроннай
+    пошты (калі вы згаджаецеся абагуліць яго). Мы не маем іншых правоў доступу.
+    Больш пра працу ўваходу праз Apple на
+    <a data-l10n-name="applehelp">вэб-сайце Apple</a>.
+
+login-workschool-q = Ці магу я выкарыстоўваць рабочы або вучэбны акаунт Microsoft?
+login-workschool-a = Так, вы можаце выкарыстоўваць любы акаўнт Microsoft, як асабісты (раней Windows Live),
+    так і бізнес-версію Azure Active Directory або Office 365, калі
+    ваш IT-аддзел не заблакіраваў гэтую магчымасць.
+
+login-otherlogin-q = Ці магу я выкарыстоўваць іншага пастаўшчыка аўтэнтыфікацыі?
+login-otherlogin-a-p1 = Цяпер падтрымліваецца ўваход праз Google, Microsoft і Apple для асабістых уліковых запісаў.
+login-otherlogin-a-p2 = Мы падтрымліваем <a data-l10n-name="saml">уваход SAML 2.0</a> для Coggle-арганізацый.
+    Калі вас цікавіць уласны хостынг Coggle з уваходам праз Active Directory, напішыце на
+    наш <a data-l10n-name="email">адрас для карпаратыўных продажаў</a>.
+
+login-pw-more-q = У мяне яшчэ ёсць пытанне пра ўваход
+login-pw-more-a = Спытайце ў нас! Наша пошта: <a data-l10n-name="email">hello@coggle.it</a>.
+
+# Organizations Landing Page (/organizations) 
+orgs-pitch-title = Coggle-арганізацыі
+orgs-pitch = Кожная Coggle-арганізацыя абсталявана функцыямі для кіравання вялікімі камандамі, калі ўдзельнікі прыходзяць і адыходзяць, а адчувальная інфармацыя павінна быць абаронена.
+
+orgs-signup = СТВАРЫЦЬ АРГАНІЗАЦЫЮ
+
+orgs-subpitch-p1 = Калі інфармацыя важная для вашай каманды, патрэбныя больш магутныя інструменты і больш кантролю над даныя. Таму мы стварылі <a data-l10n-name="orglink">Coggle-арганізацыі</a>.
+orgs-subpitch-p2 = Тарыфы простыя — <b>$8 за карыстальніка ў месяц</b>.<br><b>Неабмежавана ўсё</b>.
+
+
+orgs-feature-saml-sso-title = SAML Single Sign On
+orgs-feature-saml-sso = Аўтэнтыфікуйце карыстальнікаў праз існуючы сэрвіс адзінага ўваходу. Падтрымка OneLogin, Okta і іншых.
+
+orgs-feature-in-one-place-title = Усё ў адным месцы
+orgs-feature-in-one-place = Усе дыяграмы вашай арганізацыі ў адной прасторы. Захоўвайце працу каманды ў бяспецы — у месцы, якім лёгка кіраваць, каб вы ведалі, куды звяртацца.
+
+orgs-feature-control-sharing-title = Кантроль доступу
+orgs-feature-control-sharing = Вы можаце гарантаваць, што дыяграмы, створаныя ў арганізацыі, застануцца ў ёй. Гэта абараняе ад выпадковага доступу, калі няправільны адрас запрошаны да дакумента.
+
+orgs-feature-manage-users-title = Бяспечнае кіраванне карыстальнікамі
+orgs-feature-manage-users = Бяспечна выдаляйце ўдзельнікаў з арганізацыі, не губляючы іх уклад у працу. Скарыстайце панэль кіравання, каб прагледзець усе дыяграмы, створаныя членамі арганізацыі — як былымі, так і цяперашнімі, выдаленымі або актыўнымі.
+
+orgs-feature-export-title = Масавы экспарт
+orgs-feature-export = Адміністратары арганізацыі могуць спампаваць усе дыяграмы арганізацыі ў машыначытэльным архівавальным фармаце JSON адным націсканнем. Выдатна для рэгуляванай адпаведнасці або спакою.
+
+orgs-feature-branding-title = Пакажыце свой брэнд
+orgs-feature-branding = Стварайце прафесійныя, акуратныя дыяграмы з вашым лагатыпам і экспартуйце іх у PDF або PNG. Выдатна для пэўных прэзентацый кліентам або калегам.
+
+orgs-feature-editable-links-title = Рэдагуйце прыватныя спасылкі
+orgs-feature-editable-links = Стварайце прыватныя спасылкі для супрацоўнікаў за межамі арганізацыі, каб яны маглі рэдагаваць дыяграму без уваходу.
+
+orgs-feature-awesome = Акрамя таго, усе ўдзельнікі арганізацыі атрымаюць магчымасці <a data-l10n-name="awesome">Coggle Awesome</a>.
+
+
+# Organizations Sign-Up Page (/organizations/new) 
+orgcreate-title2 = Стварыць <a data-l10n-name="orgs">Coggle-арганізацыю</a>
+orgcreate-nameinput =
+  .placeholder = Выберыце назву арганізацыі
+orgcreate-namehint = Выберыце нешта кароткае і запамінальнае!
+orgcreate-createbutton = Стварыць
+
+faq-orgs-whatare-q = Што такое Coggle-арганізацыі?
+faq-orgs-whatare-a =
+    <p data-l10n-name='p1'>Coggle-арганізацыі ствараюць падзел паміж
+       вашымі асабістымі дыяграмамі і тымі, што належаць вашай кампаніі.
+      Падзяляючы асабістае ад прафесійнага, вы атрымліваеце большы 
+      кантроль над данымі вашай кампаніі ў Coggle, уключаючы калі і
+      як супрацоўнікі імі карыстаюцца.</p>
+
+faq-orgs-whofor-q = Для каго прызначаны Coggle-арганізацыі?
+faq-orgs-whofor-a =
+    <p data-l10n-name='p1'>Coggle-арганізацыі распрацаваны для каманд,
+      якім патрэбны большы кантроль над данымі, якія яны ўносяць у
+      Coggle, або неабходна трымаць асабістыя даныя асобна. Імі ўжо
+      паспяхова карыстаюцца прыватныя кампаніі, дзяржаўныя арганізацыі,
+      школы і ўніверсітэты для бяспечнага супрацоўніцтва.</p>
+    <p data-l10n-name='p2'>Будзь то групы, якім патрэбны кантроль над сумесным доступам да
+      дыяграм для выканання рэгулятыўных або ўнутраных правіл, яны знойдуць
+      Coggle-арганізацыі карыснымі.</p>
+
+faq-orgs-features-q = Якія асноўныя функцыі плана Coggle для Арганізацый?
+faq-orgs-features-a =
+    <p data-l10n-name='p1'><b>Панэль адміністратара</b>: поўны кантроль над дыяграмамі, створанымі
+      ўдзельнікамі вашай арганізацыі, уключаючы аднаўленне выдаленых дыяграм.</p>
+    <p data-l10n-name='p2'><b>Кіраванне данымі</b>: вы маеце выбар, каб абмежаваць доступ
+      да даных унутры арганізацыі.</p>
+    <p data-l10n-name='p3'><b>Масавы экспарт</b>: экспартуйце ўсе дыяграмы вашай арганізацыі для
+      рэзервовага капіявання або рэгулятыўных мэт.</p>
+    <p data-l10n-name='p4'><b>Цэнтралізаванае выстаўленне рахункаў</b>: аплачвайце некалькі падпісак
+      Awesome у адным месцы і адмяняйце іх па меры змены ўдзельнікаў арганізацыі.</p>
+
+faq-orgs-awesome-q = Як Coggle-арганізацыі звязаны з планам Coggle Awesome?
+faq-orgs-awesome-a =
+    <p data-l10n-name='p1'>Coggle-арганізацыі — выдатны спосаб цэнтралізаваць выстаўленне рахункаў
+      і кіраваць ліцэнзіямі для некалькіх падпісак плана Coggle Awesome.</p>
+    <p data-l10n-name='p2'>Кожны карыстальнік вашай арганізацыі аўтаматычна атрымлівае Coggle Awesome
+      пры працы з дыяграмамі ў прасторы арганізацыі. Гэта азначае ўсе функцыі,
+      уключаючы прыватныя дыяграмы, рэжым прэзентацыі, пашыраную каляровую палітру
+      і загрузку выяў высокай раздзялення.</p>
+
+faq-orgs-billing-q = Як працуе выстаўленне рахункаў у Coggle-арганізацыях?
+faq-orgs-billing-a = Coggle-арганізацыі аплачваюцца па ${$pricePerMemberPerMonth} за ўдзельніка ў месяц. Вы можаце
+  дадаваць і выдаляць удзельнікаў у любы час праз панэль кіравання арганізацыяй.
+
+faq-orgs-edu-q = Ці ёсць спецыяльныя ўмовы для адукацыі?
+faq-orgs-edu-a = Так! Звяжыцеся з намі па адрасе education@coggle.it, каб даведацца больш.
+
+faq-orgs-more-q = У мяне яшчэ ёсць пытанні...
+faq-orgs-more-a = Спытайце ў нас! Напішыце на orgs@coggle.it, і мы з радасцю дапаможам
+
+
+# About Coggle (/about) 
+about-hello2-title = Прывітанне!
+about-hello2-p1 =
+    <b>Coggle дае вам зразумелы спосаб дзяліцца і разумець складаную інфармацыю.
+    Гэта сумесны дакумент, які спрашчае складаныя рэчы, і агульная прастора,
+    якая дапамагае вашай камандзе працаваць эфектыўней разам.</b>
+about-hello2-p2 =
+    Гэта бясплатна, і мы абяцаем, што так будзе заўсёды, але мы ўсё роўна
+    будзем клапаціцца пра вашыя даныя найлепшым чынам, рабіць рэзервовыя
+    копіі і ўспрымаць бяспеку сур’ёзна.
+about-hello2-p3 =
+    Наша місія — змяніць спосаб, якім людзі працуюць і супрацоўнічаюць
+    назаўсёды: зрабіць вас больш прадукцыйнымі, палегчыць абмен інфармацыяй
+    і зрабіць гэта прыгожа і прыемна ў карыстанні.
+
+  
+
+about-what-is-mindmapping-title = Што такое майндмэпінг?
+about-what-is-mindmapping =
+    Майнд-карта — гэта просты спосаб візуальна адлюстраваць тэму ў арганічнай
+    форме. Яна пачынаецца з аднаго або некалькіх цэнтральных пунктаў і раз за
+    разам разгаліноўваючыся, разбіваючы інфармацыю на іерархію кампанентаў.<br>
+    Элементы майнд-карты можна размяшчаць у прасторы і фармаціраваць па памеры
+    і колеры, каб палепшыць успрыманне і запамінанне. Майндмэпінг мае шмат
+    назваў: канцэптуальнае мапаванне, павуцінныя дыяграмы, дыяграмы мазгавога
+    штурму і іншыя, але вы можаце выкарыстоўваць Coggle для ўсяго з гэтага!
+
+
+
+about-who-is-mindmapping-for-title = Для каго падыходзяць майнд-карты?
+about-who-is-mindmapping-for =
+    Майнд-карты карысныя для тых, хто плануе, вядзе нататкі, візуалізуе інфармацыю,
+    робіць мазгавыя штурмы, вырашае праблемы, вучыцца і дзеліцца інфармацыяй
+    (і гэта толькі некалькі прыкладаў). Іх ужыванне не мае абмежаванняў!<br>
+    Усе, хто цэніць візуальнае мысленне ў бізнесе, адукацыі ці асабістым жыцці,
+    могуць знайсці майнд-карты карыснымі для арганізавання інфармацыі.
+
+
+
+about-getintouch-title = Звяжыцеся з намі
+about-getintouch =
+    Маеце пытанне? Хочаце расказаць, як вы карыстаецеся Coggle? Ці проста
+    пакінуць водгук? Вы можаце знайсці нас на <a data-l10n-name="facebook">Facebook</a> і ў
+    <a data-l10n-name="x">X</a>, а калі вам зручней — вы заўсёды можаце напісаць на
+    <a data-l10n-name="email">hello@coggle.it</a> — нам прыемна пагаварыць!
+
+
+about-share-title = Раскажыце пра нас
+about-share =
+  Калі вам падабаецца Coggle, дапамажыце вызваліць яшчэ больш людзей ад абмежаванняў
+  спісаў, табліц і традыцыйных дакументаў! Вы можаце падзяліцца Coggle
+  <a data-l10n-name="x">ў X</a> або <a data-l10n-name="facebook">на Facebook</a>.
+
+about-itp-title = У прэсе?
+about-itp = Тады азнаёмцеся з нашым <a data-l10n-name="kit">прэс-наборам</a> або <a data-l10n-name="email">звязацца з намі</a>, каб даведацца больш!
+
+
+# Coggle Facts 
+fact-math = Ці ведалі вы, што ў Coggle можна пісаць матэматычныя формулы? (Так, гікі!) Выкарыстоўвайце \\( LaTeX тут \\) для праверкі!
+
+fact-collaborate = Ці ведалі вы, што можна супрацоўнічаць у рэальным часе з іншымі? Можна! Выкарыстоўвайце кнопку (+) у правым верхнім вугле.
+
+fact-share = Ці ведалі вы, што можна рэдагаваць Coggle адначасова з кімсьці іншым? Можна! Каб запрасіць іншых, выкарыстоўвайце кнопку (+) у правым верхнім вугле.
+
+fact-font = Ці ведалі вы, што можна выкарыстоўваць шрыфт фіксаванай шырыні ў Coggle? Можна!<br>Проста заключыце тэкст у `адваротныя апострафы`, гэта таксама блакіруе інтэрпрэтацыю іншага сінтаксісу.
+
+fact-bold = Ці ведалі вы, што можна выкарыстоўваць **тлусты тэкст** у Coggle?<br>Проста заключыце тэкст у **двайныя зорачкі**, каб вылучыць яго!
+
+fact-italic = Ці ведалі вы, што можна выкарыстоўваць *курсіўны тэкст* у Coggle?<br>Проста заключыце тэкст у *зорачкі*, каб вылучыць яго!
+
+fact-links = Ці ведалі вы, што можна дадаваць спасылкі ў Coggle? Можна!<br>Яны працуюць так:<br>[апісанне](http://example.com)
+
+fact-download = Ці ведалі вы, што можна спампаваць сваю карту з Coggle у фармаце PDF або відарыса? Можна! Шукайце кнопку спампоўвання ў правым верхнім вугле экрана.
+
+fact-markdown = Ці ведалі вы, што Coggle выкарыстоўвае <a data-l10n-name='link'>сінтаксіс Markdown</a>? Гэта праўда!<br>Паспрабуйце аформіць спасылку вось так: &lt;http://example.com&gt;
+
+fact-latex = Ці ведалі вы, што Coggle падтрымлівае фармулы LaTeX? Ён падтрымлівае!<br>Выкарыстоўвайце \\( LaTeX тут \\) для праверкі! Паглядзіце <a data-l10n-name='link'>гэтую спасылку</a> для дапамогі з сінтаксісам.
+
+fact-move = Хочаце перамясціць элемент у іншае месца ў Coggle? Без праблем! Утрымлівайце [shift] падчас перацягвання кнопкі (+) элемента, каб прымацаваць яго іначай.
+
+fact-fontsize = Памер тэксту занадта велізарны? Занадта малы? Можна маштабіраваць!<br>Выкарыстоўвайце [ctrl] [+] / [ctrl] [-]
+
+fact-zoomin = Ці ведалі вы, што можна наблізіць экран для падрабязнага прагляду? Можна!<br>Выкарыстоўвайце [ctrl] [+] або націсніце правай кнопкай і цягніце значок маштабу!
+
+fact-zoomout = Ці ведалі вы, што можна адысці для агульнага погляду? Можна!<br>Выкарыстоўвайце [ctrl] [-] або націсніце правай кнопкай і цягніце значок маштабу!
+
+fact-markdown2 = Ці ведалі вы, што <a data-l10n-name='link'>Markdown</a> цудоўны? Ён такі, і Coggle яго падтрымлівае!
+
+fact-pdf = Вы можаце спампаваць свой Coggle у фармаце PDF! Шукайце кнопку спампоўкі ў правым верхнім вугле экрана.
+
+fact-png = Вы можаце спампаваць свой Coggle як відарыс! Шукайце кнопку спампоўкі ў правым верхнім вугле экрана.
+
+fact-latex2 = Ці ведалі вы, што Coggle падтрымлівае LaTeX для матэматыкі? Ён падтрымлівае!<br>Выкарыстоўвайце \\( \\LaTeX тут \\) для праверкі! Вось <a data-l10n-name='link'>даведнік па сінтаксісе</a>.
+
+fact-history = Ці ведалі вы, што можна праглядаць гісторыю змен — хто і калі што змяніў у вашым Coggle? Можна! Націсніце на значок гадзінніка ў правым верхнім вугле.
+
+fact-images = Ці ведалі вы, што можна дадаваць відарысы ў ваш Coggle? Можна!<br>Проста перацягніце відарыс з камп’ютара ў патрэбнае месца.
+
+fact-images2 = Ці ведалі вы, што можна выкарыстоўваць відарысы ў Coggle? Можна!<br>Перацягніце відарыс з камп’ютара ў патрэбнае месца. Мініяцюра відарыса будзе загружана і захавана!
+
+fact-plaintext-in = Ці ведалі вы, што можна перацягваць звычайныя тэкставыя файлы ў Coggle для імпартавання? Можна!<br>Калі файл мае водступы, Coggle нават дадасць структуру да імпартаванага тэксту.
+
+fact-freemind-in = Ці ведалі вы, што можна перацягваць Freemind .mm-файлы ў Coggle для імпартавання? Можна!
+
+fact-link-drag = Ці ведалі вы, што можна перацягнуць URL з адраснага радка ў Coggle, каб стварыць спасылку на гэты сайт? Можна!
+
+fact-text-size = Ці ведалі вы, што можна змяняць памер тэксту? Можна!<br>Выкарыстоўвайце #, ## або ### на пачатку радка для павелічэння памеру.
+
+fact-text-size2 = Ці ведалі вы, што можна змяняць памер тэксту? Можна!<br>Перацягніце вугал вобласці рэдагавання тэксту ўверх або ўніз.
+
+fact-text-size3 = Ці ведалі вы, што можна змяняць памер тэксту? Можна!<br>Перацягніце вугал вобласці рэдагавання тэксту.
+
+fact-md-reference = Ці ведалі вы, што можна выкарыстоўваць Markdown у Coggle для дадавання спасылак, выяў і іншага? Можна!<br>Вось <a data-l10n-name='link'>поўны даведнік</a>.
+
+fact-multiline-keys = Ці ведалі вы, што можна разбіваць тэкст на некалькі радкоў? Можна! Утрымлівайце [ctrl] і націскайце [return], каб уставіць перанос. Таксама можна перацягнуць вугал поля рэдагавання, а затым выкарыстоўваць [return] як звычайна.
+
+fact-multiline-drag = Ці ведалі вы, што можна разбіваць тэкст на некалькі радкоў? Можна! Перацягніце вугал поля рэдагавання, тады [return] будзе ўстаўляць перанос замест захоўвання. Таксама можна ўтрымліваць [ctrl] і націскаць [return] падчас набору.
+
+fact-multiline-wrap = Ці ведалі вы, што можна разбіваць тэкст на некалькі радкоў? Можна! Перацягніце вугал вобласці рэдагавання тэксту ўлева або ўправа, каб абгортваць тэкст на некалькіх радках.
+
+fact-resize-images = Ці ведалі вы, што можна змяняць памер выяў? Можна! Перацягніце відарыс у Coggle з любога месца ў інтэрнэце (калі ў вас ёсць на гэта дазвол), а затым перацягніце ніжні правы вугал відарысы для змены памеру.
+
+fact-image-size = Ці ведалі вы, што мы падтрымліваем пашырэнне Markdown для ўказання памеру відарыса? Можна! Вызначыце відарыс памерам 200 на 100 пікселяў так: ![апісанне відарыса](http://url.to.image "неабавязковы загаловак" 200x100)
+
+fact-bold-kbshort = Ці ведалі вы, што можна выкарыстоўваць спалучэнні клавіш для **тлустага тэксту** ў Coggle? Можна! Проста націсніце [ctrl]+[b] (або [cmd]+[b] на Mac) з абраным тэкстам.
+
+fact-shortcuts-1 = Ці ведалі вы, што можна рэдагаваць Coggle толькі з дапамогай клавіятуры? Можна, вось як:<br>[tab] для дадавання дзіцячага вузла<br>[shift]+[tab] для пераходу да бацькоўскага<br>[shift]+[return] для дадавання вузла на тым жа ўзроўні
+
+fact-shortcuts-2 = Ці ведалі вы, што можна выбраць галіну для рэдагавання з дапамогай спалучэнняў клавіш? Можна!<br>Выкарыстоўвайце [alt]+[shift]+клавішы са стрэлкамі для перамяшчэння па галінках.
+
+fact-task-lists = Ці ведалі вы, што можна выкарыстоўваць <a data-l10n-name='link'>Markdown</a> для дадавання спісаў задач у Coggle? Можна, вось прыклад:<br>- [ ] поле без птушкі<br>- [X] поле з птушкай<br>Націсканне па полі аўтаматычна змяняе код Markdown.
+
+fact-api-1 = Ці ведалі вы, што ў нас ёсць API? Ён ёсць! Праграмы могуць аўтаматычна выкарыстоўваць яго для стварэння, прагляду і кіравання Coggle.
+
+fact-organisation = Вы карыстаецеся Coggle у бізнесе? Вы можаце стварыць Coggle-арганізацыю для кіравання дыяграмамі вашай кампаніі.
+
+fact-organisation2 = Ці ведалі вы, што Coggle-арганізацыі могуць размяшчаць свой лагатып на сваіх дыяграмах? Яны могуць!
+
+fact-organisation3 = Ці ведалі вы, што можна стварыць Coggle-арганізацыю, каб арганізаваць дыяграмы вашай кампаніі? Можна!
+


### PR DESCRIPTION
Hi! It was a while from the first time I've made translation into Belarusian language. Decided to revive the translation with new Mozilla format, it was retranslated from zero, partly with AI, but mostly it looks OK now. If I'll find some places to proofread, then I'll make another PR, but it looks not bad now and there will be no big issues with it for sure.

I have nothing against deletion of the legacy Belarusian translations btw. I have much more experience now with technical translations and it looks pretty deprecated, like an artifact of distant past :)
But there is not much value in it now.

Also, I have little message to your team as a translator with some experience. I found no CAT-tools to work with this Mozilla's format of files. Only found Pontoon and some solutions on Crowdin, but it's all online and there is no way that individual translators will try to make some project for a separate l10n. So I recommend your team to consider deploying a project on any of those CAT platforms (ideally a public project on Crowdin, it is the best on the market now; not affilated with them though). This will make all l10ns much better and will bring more contribitors with more languages to your project.